### PR TITLE
chore: clean up resource naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform-version
+.terraform/**
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Want to host a static website on AWS simply and (theoretically) cheaply? Let S3,
 
 ## Terraform versions
 
-I've tested this on 0.13 onward, and seems to be fine. If you find an issue, feel free to raise an issue.
+I've tested this on 1.5.5, and seems to be fine. If you find an issue, feel free to raise an issue.
 
 ### Example Usage
 
@@ -58,6 +58,7 @@ module "prod_website" {
 
 - `deployer_creds`: When this and `deployer_iam_user` are set to `true`, Outputs the `access_key` and `secret_key` of the created IAM user.
   - Note: If `deployer_iam_user` is set to false, this will render as `undefined`
+- `distribution_id`: Shows the ID of the created CloudFront distribution. Helpful with automation for invalidating cache.
 
 ## Authors
 

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = aws_cloudfront_origin_access_identity.staticsite-oai
+  to   = aws_cloudfront_origin_access_identity.this
+}

--- a/moved.tf
+++ b/moved.tf
@@ -57,3 +57,8 @@ moved {
   from = aws_route53_record.staticsite-route53-a
   to   = aws_route53_record.cloudfront_a
 }
+
+moved {
+  from = aws_iam_user.staticsite-iam-deployer
+  to   = aws_iam_user.deployer
+}

--- a/moved.tf
+++ b/moved.tf
@@ -1,4 +1,0 @@
-moved {
-    from = aws_cloudfront_origin_access_identity.staticsite-oai
-    to = aws_cloudfront_origin_access_identity.this
-}

--- a/moved.tf
+++ b/moved.tf
@@ -27,3 +27,33 @@ moved {
   from = aws_s3_bucket.staticsite-s3
   to   = aws_s3_bucket.this
 }
+
+moved {
+  from = aws_s3_bucket_policy.staticsite-s3
+  to   = aws_s3_bucket_policy.this
+}
+
+moved {
+  from = aws_s3_bucket_cors_configuration.staticsite-s3
+  to   = aws_s3_bucket_cors_configuration.this
+}
+
+moved {
+  from = aws_s3_bucket_acl.staticsite-s3
+  to   = aws_s3_bucket_acl.this
+}
+
+moved {
+  from = aws_s3_bucket_website_configuration.staticsite-s3
+  to   = aws_s3_bucket_website_configuration.this
+}
+
+moved {
+  from = aws_cloudfront_function.staticsite-indexhandler
+  to   = aws_cloudfront_function.index_handler
+}
+
+moved {
+  from = aws_route53_record.staticsite-route53-a
+  to   = aws_route53_record.cloudfront_a
+}

--- a/moved.tf
+++ b/moved.tf
@@ -22,3 +22,8 @@ moved {
   from = aws_cloudfront_distribution.staticsite-cf
   to   = aws_cloudfront_distribution.this
 }
+
+moved {
+  from = aws_s3_bucket.staticsite-s3
+  to   = aws_s3_bucket.this
+}

--- a/moved.tf
+++ b/moved.tf
@@ -9,6 +9,16 @@ moved {
 }
 
 moved {
+  from = aws_route53_record.staticsite-acm-cert-validate
+  to   = aws_route53_record.cert_validation
+}
+
+moved {
+  from = aws_acm_certificate_validation.staticsite-acm
+  to   = aws_acm_certificate_validation.this
+}
+
+moved {
   from = aws_cloudfront_distribution.staticsite-cf
   to   = aws_cloudfront_distribution.this
 }

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,4 @@
+moved {
+    from = aws_cloudfront_origin_access_identity.staticsite-oai
+    to = aws_cloudfront_origin_access_identity.this
+}

--- a/moved.tf
+++ b/moved.tf
@@ -62,3 +62,13 @@ moved {
   from = aws_iam_user.staticsite-iam-deployer
   to   = aws_iam_user.deployer
 }
+
+moved {
+  from = aws_iam_access_key.staticsite-iam-deployer
+  to   = aws_iam_access_key.deployer
+}
+
+moved {
+  from = aws_iam_user_policy.staticsite-iam-deployer
+  to   = aws_iam_user_policy.deployer
+}

--- a/moved.tf
+++ b/moved.tf
@@ -2,3 +2,8 @@ moved {
   from = aws_cloudfront_origin_access_identity.staticsite-oai
   to   = aws_cloudfront_origin_access_identity.this
 }
+
+moved {
+  from = aws_acm_certificate.staticsite-acm-cert
+  to   = aws_acm_certificate.this
+}

--- a/moved.tf
+++ b/moved.tf
@@ -7,3 +7,8 @@ moved {
   from = aws_acm_certificate.staticsite-acm-cert
   to   = aws_acm_certificate.this
 }
+
+moved {
+  from = aws_cloudfront_distribution.staticsite-cf
+  to   = aws_cloudfront_distribution.this
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,6 @@ output "deployer_creds" {
 
 output "distribution_id" {
   description = "Cloudfront distribution ID"
-  value       = aws_cloudfront_distribution.staticsite-cf.id
+  value       = aws_cloudfront_distribution.this.id
   sensitive   = false
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,10 +2,10 @@ output "deployer_creds" {
   description = "Credentials for the deployer user. Useful as an output for programmatic processes to grab via the Terraform state JSON."
   value = {
     access_key = (
-      var.deployer_iam_user ? aws_iam_access_key.staticsite-iam-deployer[0].id : "undefined"
+      var.deployer_iam_user ? aws_iam_access_key.deployer[0].id : "undefined"
     )
     secret_key = (
-      var.deployer_iam_user ? aws_iam_access_key.staticsite-iam-deployer[0].secret : "undefined"
+      var.deployer_iam_user ? aws_iam_access_key.deployer[0].secret : "undefined"
     )
     default_region = var.aws_region
   }

--- a/resources.tf
+++ b/resources.tf
@@ -46,7 +46,7 @@ resource "aws_acm_certificate_validation" "this" {
 
 resource "aws_cloudfront_distribution" "this" {
   origin {
-    domain_name = aws_s3_bucket.staticsite-s3.bucket_regional_domain_name
+    domain_name = aws_s3_bucket.this.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
 
     s3_origin_config {
@@ -104,7 +104,7 @@ resource "aws_cloudfront_distribution" "this" {
 
 }
 
-resource "aws_s3_bucket" "staticsite-s3" {
+resource "aws_s3_bucket" "this" {
   bucket = var.s3_bucket_name
   tags   = var.tags
 }
@@ -218,7 +218,7 @@ resource "aws_iam_user_policy" "staticsite-iam-deployer" {
           ]
           Effect = "Allow"
           Resource = [
-            aws_s3_bucket.staticsite-s3.arn,
+            aws_s3_bucket.this.arn,
             aws_cloudfront_distribution.this.arn
           ]
         },
@@ -230,7 +230,7 @@ resource "aws_iam_user_policy" "staticsite-iam-deployer" {
             "s3:ListObject*"
           ]
           Effect   = "Allow"
-          Resource = "${aws_s3_bucket.staticsite-s3.arn}/*"
+          Resource = "${aws_s3_bucket.this.arn}/*"
         },
         {
           Action   = "cloudfront:ListDistributions"

--- a/resources.tf
+++ b/resources.tf
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "staticsite-cf" {
     origin_id   = local.s3_origin_id
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.staticsite-oai.cloudfront_access_identity_path
+      origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
     }
   }
 
@@ -128,7 +128,7 @@ resource "aws_s3_bucket_policy" "staticsite-s3" {
             "arn:aws:s3:::${var.s3_bucket_name}"
           ]
           Principal = {
-            AWS = aws_cloudfront_origin_access_identity.staticsite-oai.iam_arn
+            AWS = aws_cloudfront_origin_access_identity.this.iam_arn
           }
         }
       ]

--- a/resources.tf
+++ b/resources.tf
@@ -7,7 +7,7 @@ locals {
   s3_origin_id     = "${local.primary_domain}-s3_origin"
 }
 
-resource "aws_cloudfront_origin_access_identity" "staticsite-oai" {
+resource "aws_cloudfront_origin_access_identity" "this" {
   comment = var.oai_comment
 }
 

--- a/resources.tf
+++ b/resources.tf
@@ -192,21 +192,21 @@ resource "aws_route53_record" "cloudfront_a" {
   }
 }
 
-resource "aws_iam_user" "staticsite-iam-deployer" {
+resource "aws_iam_user" "deployer" {
   count = var.deployer_iam_user ? 1 : 0
   name  = var.deployer_iam_user_name
   tags  = var.tags
 }
 
-resource "aws_iam_access_key" "staticsite-iam-deployer" {
+resource "aws_iam_access_key" "deployer" {
   count = var.deployer_iam_user ? 1 : 0
-  user  = aws_iam_user.staticsite-iam-deployer[0].name
+  user  = aws_iam_user.deployer[0].name
 }
 
-resource "aws_iam_user_policy" "staticsite-iam-deployer" {
+resource "aws_iam_user_policy" "deployer" {
   count = var.deployer_iam_user ? 1 : 0
-  name  = "${aws_iam_user.staticsite-iam-deployer[0].name}_user_policy"
-  user  = aws_iam_user.staticsite-iam-deployer[0].name
+  name  = "${aws_iam_user.deployer[0].name}_user_policy"
+  user  = aws_iam_user.deployer[0].name
   policy = jsonencode(
     {
       Version = "2012-10-17"

--- a/resources.tf
+++ b/resources.tf
@@ -1,10 +1,10 @@
 locals {
-  domain_list      = var.domain_list
-  primary_domain   = var.domain_list[0]
+  domain_list              = var.domain_list
+  primary_domain           = var.domain_list[0]
   sanitized_primary_domain = replace(local.primary_domain, ".", "-")
-  domain_list_full = distinct(concat(tolist([local.primary_domain]), local.domain_list))
-  san_list         = slice(local.domain_list_full, 1, length(local.domain_list_full))
-  s3_origin_id     = "${local.primary_domain}-s3_origin"
+  domain_list_full         = distinct(concat(tolist([local.primary_domain]), local.domain_list))
+  san_list                 = slice(local.domain_list_full, 1, length(local.domain_list_full))
+  s3_origin_id             = "${local.primary_domain}-s3_origin"
 }
 
 resource "aws_cloudfront_origin_access_identity" "this" {
@@ -61,7 +61,7 @@ resource "aws_cloudfront_distribution" "staticsite-cf" {
   aliases             = local.domain_list
   price_class         = "PriceClass_100"
   tags                = var.tags
-  web_acl_id = length(var.ip_allow_list) >= 1 ? aws_wafv2_web_acl.this[0].arn : null
+  web_acl_id          = length(var.ip_allow_list) >= 1 ? aws_wafv2_web_acl.this[0].arn : null
   depends_on = [
     aws_acm_certificate_validation.staticsite-acm
   ]
@@ -155,7 +155,7 @@ resource "aws_s3_bucket_cors_configuration" "staticsite-s3" {
 }
 
 resource "aws_s3_bucket_acl" "staticsite-s3" {
-  count = var.skip_acl ? 0 : 1
+  count  = var.skip_acl ? 0 : 1
   bucket = var.s3_bucket_name
   acl    = "private"
 }
@@ -212,11 +212,11 @@ resource "aws_iam_user_policy" "staticsite-iam-deployer" {
       Version = "2012-10-17"
       Statement = [
         {
-          Action   = [
+          Action = [
             "s3:ListBucket",
             "cloudfront:CreateInvalidation"
           ]
-          Effect   = "Allow"
+          Effect = "Allow"
           Resource = [
             aws_s3_bucket.staticsite-s3.arn,
             aws_cloudfront_distribution.staticsite-cf.arn
@@ -233,8 +233,8 @@ resource "aws_iam_user_policy" "staticsite-iam-deployer" {
           Resource = "${aws_s3_bucket.staticsite-s3.arn}/*"
         },
         {
-          Action = "cloudfront:ListDistributions"
-          Effect = "Allow"
+          Action   = "cloudfront:ListDistributions"
+          Effect   = "Allow"
           Resource = "*"
         }
       ]

--- a/resources.tf
+++ b/resources.tf
@@ -84,7 +84,7 @@ resource "aws_cloudfront_distribution" "this" {
       for_each = var.cloudfront_index_handler == true ? [1] : []
       content {
         event_type   = "viewer-request"
-        function_arn = aws_cloudfront_function.staticsite-indexhandler.arn
+        function_arn = aws_cloudfront_function.index_handler.arn
       }
     }
   }
@@ -109,7 +109,7 @@ resource "aws_s3_bucket" "this" {
   tags   = var.tags
 }
 
-resource "aws_s3_bucket_policy" "staticsite-s3" {
+resource "aws_s3_bucket_policy" "this" {
   bucket = var.s3_bucket_name
   policy = jsonencode(
     {
@@ -136,7 +136,7 @@ resource "aws_s3_bucket_policy" "staticsite-s3" {
   )
 }
 
-resource "aws_s3_bucket_cors_configuration" "staticsite-s3" {
+resource "aws_s3_bucket_cors_configuration" "this" {
   bucket = var.s3_bucket_name
 
   cors_rule {
@@ -154,13 +154,13 @@ resource "aws_s3_bucket_cors_configuration" "staticsite-s3" {
   }
 }
 
-resource "aws_s3_bucket_acl" "staticsite-s3" {
+resource "aws_s3_bucket_acl" "this" {
   count  = var.skip_acl ? 0 : 1
   bucket = var.s3_bucket_name
   acl    = "private"
 }
 
-resource "aws_s3_bucket_website_configuration" "staticsite-s3" {
+resource "aws_s3_bucket_website_configuration" "this" {
   bucket = var.s3_bucket_name
 
   index_document {
@@ -172,14 +172,14 @@ resource "aws_s3_bucket_website_configuration" "staticsite-s3" {
   }
 }
 
-resource "aws_cloudfront_function" "staticsite-indexhandler" {
+resource "aws_cloudfront_function" "index_handler" {
   name    = "${var.oai_comment}_index_handler"
   runtime = "cloudfront-js-1.0"
   publish = true
   code    = file("${path.module}/cloudfront_index_handler.js")
 }
 
-resource "aws_route53_record" "staticsite-route53-a" {
+resource "aws_route53_record" "cloudfront_a" {
   for_each        = toset(local.domain_list)
   allow_overwrite = true
   name            = each.key

--- a/resources.tf
+++ b/resources.tf
@@ -11,7 +11,7 @@ resource "aws_cloudfront_origin_access_identity" "this" {
   comment = var.oai_comment
 }
 
-resource "aws_acm_certificate" "staticsite-acm-cert" {
+resource "aws_acm_certificate" "this" {
   domain_name               = local.primary_domain
   validation_method         = "DNS"
   subject_alternative_names = local.san_list
@@ -23,7 +23,7 @@ resource "aws_acm_certificate" "staticsite-acm-cert" {
 
 resource "aws_route53_record" "staticsite-acm-cert-validate" {
   for_each = {
-    for dvo in aws_acm_certificate.staticsite-acm-cert.domain_validation_options : dvo.domain_name => {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
@@ -38,7 +38,7 @@ resource "aws_route53_record" "staticsite-acm-cert-validate" {
 }
 
 resource "aws_acm_certificate_validation" "staticsite-acm" {
-  certificate_arn = aws_acm_certificate.staticsite-acm-cert.arn
+  certificate_arn = aws_acm_certificate.this.arn
   validation_record_fqdns = [
     for record in aws_route53_record.staticsite-acm-cert-validate : record.fqdn
   ]
@@ -91,7 +91,7 @@ resource "aws_cloudfront_distribution" "staticsite-cf" {
 
   viewer_certificate {
     cloudfront_default_certificate = false
-    acm_certificate_arn            = aws_acm_certificate.staticsite-acm-cert.arn
+    acm_certificate_arn            = aws_acm_certificate.this.arn
     ssl_support_method             = "sni-only"
   }
 


### PR DESCRIPTION
- clean up resource names, using `aws_whateve_resource.this` for single resources that are not duplicated, and communicative but brief names for others
- create `moved {}` blocks so that existing users are held harmless
- update README